### PR TITLE
GitHub Action to lint Python code

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,20 +1,18 @@
-name: itinerant_tester
+name: lint_python
 on:
   pull_request:
   push:
   #  branches: [master]
 jobs:
-  itinerant_tester:
+  lint_python:
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]    # [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.9]  # [2.7, 3.5, 3.6, 3.7, 3.8, pypy3]
-        repo: ["https://github.com/google/oss-fuzz", "https://github.com/cclauss/itinerant-tester"]
     runs-on: ${{ matrix.os }}
     steps:
-      # - uses: actions/checkout@v2
-      - run: git clone ${{ matrix.repo }}
+      - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
@@ -27,6 +25,6 @@ jobs:
       #    black --check . || true
       - run: codespell --quiet-level=2 || true  # --ignore-words-list="" --skip=""
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-      - run: isort --profile black --recursive . || true
+      - run: isort --profile black . || true
       - run: pip install -r requirements.txt || true
       - run: pytest . || true

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,0 +1,32 @@
+name: itinerant_tester
+on:
+  pull_request:
+  push:
+  #  branches: [master]
+jobs:
+  itinerant_tester:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]    # [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.9]  # [2.7, 3.5, 3.6, 3.7, 3.8, pypy3]
+        repo: ["https://github.com/google/oss-fuzz", "https://github.com/cclauss/itinerant-tester"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      # - uses: actions/checkout@v2
+      - run: git clone ${{ matrix.repo }}
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install black codespell flake8 isort pytest
+      - run: black --check . || true
+      # - run: black --diff . || true
+      # - if: matrix.python-version >= 3.6
+      #  run: |
+      #    pip install black
+      #    black --check . || true
+      - run: codespell --quiet-level=2 || true  # --ignore-words-list="" --skip=""
+      - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+      - run: isort --profile black --recursive . || true
+      - run: pip install -r requirements.txt || true
+      - run: pytest . || true

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -9,7 +9,7 @@ jobs:
       - run: pip install bandit black codespell flake8 isort mypy pytest pyupgrade safety
       - run: bandit -r . || true
       - run: black --check . || true
-      - run: codespell --quiet-level=2 || true  # --ignore-words-list="" --skip=""
+      - run: codespell --ignore-words-list="fo" --quiet-level=2 || true  # --skip=""
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
       - run: isort --check-only --profile black . || true
       - run: pip install -r requirements.txt || true

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -12,7 +12,7 @@ jobs:
       - run: codespell --ignore-words-list="fo" --quiet-level=2 || true  # --skip=""
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
       - run: isort --check-only --profile black . || true
-      - run: pip install -r requirements.txt || true
+      - run: pip install -r requirements/requirements.txt
       - run: mypy --ignore-missing-imports . || true
       - run: pytest . || true
       - run: pytest --doctest-modules . || true

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -3,9 +3,15 @@ on: [pull_request, push]
 jobs:
   lint_python:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
       - run: pip install bandit black codespell flake8 isort mypy pytest pyupgrade safety
       - run: bandit -r . || true
       - run: black --check . || true

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -6,13 +6,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7]  # [3.6, 3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - run: apt-get install ffmpeg
+      - run: sudo apt-get install ffmpeg
       - run: pip install bandit black codespell flake8 isort mypy pytest pyupgrade safety
       - run: bandit -r . || true
       - run: black --check . || true

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,30 +1,20 @@
 name: lint_python
-on:
-  pull_request:
-  push:
-  #  branches: [master]
+on: [pull_request, push]
 jobs:
   lint_python:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest]    # [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.9]  # [2.7, 3.5, 3.6, 3.7, 3.8, pypy3]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - run: pip install black codespell flake8 isort pytest
+      - run: pip install bandit black codespell flake8 isort mypy pytest pyupgrade safety
+      - run: bandit -r . || true
       - run: black --check . || true
-      # - run: black --diff . || true
-      # - if: matrix.python-version >= 3.6
-      #  run: |
-      #    pip install black
-      #    black --check . || true
       - run: codespell --quiet-level=2 || true  # --ignore-words-list="" --skip=""
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-      - run: isort --profile black . || true
+      - run: isort --check-only --profile black . || true
       - run: pip install -r requirements.txt || true
+      - run: mypy --ignore-missing-imports . || true
       - run: pytest . || true
+      - run: pytest --doctest-modules . || true
+      - run: shopt -s globstar && pyupgrade --py36-plus **/*.py || true
+      - run: safety check

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+      - run: apt-get install ffmpeg
       - run: pip install bandit black codespell flake8 isort mypy pytest pyupgrade safety
       - run: bandit -r . || true
       - run: black --check . || true


### PR DESCRIPTION
Output: https://github.com/cclauss/pyAudioProcessing/actions opened ~#4,~ #20, #21, #22

https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead, these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python, they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python, a __NameError__ is raised which will halt/crash the script on the user.