### PR TITLE
Mypy: evaluateclassifier is both imported and defined

### DIFF
--- a/pyAudioProcessing/trainer/audioTrainTest.py
+++ b/pyAudioProcessing/trainer/audioTrainTest.py
@@ -10,7 +10,7 @@ import ntpath
 import sklearn
 import pyAudioProcessing.features.audioFeatureExtraction as aF
 from pyAudioAnalysis.audioTrainTest import (
-    evaluateclassifier, writeTrainDataToARFF, normalizeFeatures, trainSVM,
+    writeTrainDataToARFF, normalizeFeatures, trainSVM,
     trainSVM_RBF, trainRandomForest, trainGradientBoosting, trainExtraTrees,
     listOfFeatures2Matrix, evaluateRegression, trainSVMregression,
     trainSVMregression_rbf, trainRandomForestRegression, load_model_knn,


### PR DESCRIPTION
[`evaluateclassifier`](https://github.com/jsingh811/pyAudioProcessing/search?q=evaluateclassifier) is imported on line 13, defined on line 65, and used on line 291.

$ `mypy --ignore-missing-imports .`
```
pyAudioProcessing/trainer/audioTrainTest.py:65: error: Name 'evaluateclassifier' already defined (possibly by an import)
Found 1 error in 1 file (checked 11 source files)
```

http://mypy-lang.org