### PR TITLE
Bumped dependencies to support Python 3.12

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,9 +1,12 @@
-numpy==1.22.0;python_version>="3.8"
+numpy==2.2.6;python_version>="3.12"
 numpy==1.21.6;python_version=="3.7"
 numpy==1.19.5;python_version<"3.7"
-matplotlib==3.3.4
-scipy==1.5.4
-scikit-learn==1.1.1;python_version>="3.8"
+matplotlib==3.10.0;python_version>="3.12"
+matplotlib==3.3.4;python_version<"3.12"
+scipy==1.16.0;python_version>="3.12"
+scipy==1.5.4;python_version<"3.12"
+scikit-learn==1.7.0;python_version>="3.12"
+scikit-learn==1.1.1;python_version<"3.12"
 scikit-learn==0.24.2;python_version<="3.7"
 pydub==0.25.1
 ffmpeg==1.4


### PR DESCRIPTION
Bumped numpy to 2.2.6, matplotlib to 3.10.0, scipy to 1.16.0 and scikit-learn to 1.7.0 to use pyAudioProcessing with Python 3.12.